### PR TITLE
Redirect test

### DIFF
--- a/test/features/GithubApi.Redirect.feature
+++ b/test/features/GithubApi.Redirect.feature
@@ -1,7 +1,7 @@
 Feature: Github Api Redirect Test
     Scenario: Verify redirect for a repository
-        Given a Github a repository old URL
-        And the Github repository new URL
+        Given a Github a repository old URL 'https://github.com/aperdomob/redirect-test'
+        And the Github repository new URL 'https://github.com/aperdomob/new-redirect-test'
         When a request is used to obtain information of the repository, with the old URL
         Then the response should contain a 'Moved-Permanently' status
         And the repository redirect information

--- a/test/features/GithubApi.Redirect.feature
+++ b/test/features/GithubApi.Redirect.feature
@@ -1,0 +1,10 @@
+Feature: Github Api Redirect Test
+    Scenario: Verify redirect for a repository
+        Given a Github a repository old URL
+        And the Github repository new URL
+        When a request is used to obtain information of the repository, with the old URL
+        Then the response should contain a 'Moved-Permanently' status
+        And the repository redirect information
+        When a request is used to retrieve the repository with the old URL
+        Then the response should contain a 'OK' status
+        And the response must contain a redirect to the new URL

--- a/test/features/GithubApi.Redirect.feature
+++ b/test/features/GithubApi.Redirect.feature
@@ -4,7 +4,7 @@ Feature: Github Api Redirect Test
         And the Github repository new URL 'https://github.com/aperdomob/new-redirect-test'
         When a request is used to obtain information of the repository, with the old URL
         Then the response should contain a 'Moved-Permanently' status
-        And the repository redirect information
+        And the response must contain a header with the redirect url
         When a request is used to retrieve the repository with the old URL
         Then the response should contain a 'OK' status
         And the response must contain a redirect to the new URL

--- a/test/features/support/GithubAPI/Redirect/RedirectSteps.js
+++ b/test/features/support/GithubAPI/Redirect/RedirectSteps.js
@@ -25,7 +25,7 @@ When('a request is used to obtain information of the repository, with the old UR
   }
 });
 
-Then('the repository redirect information', function () {
+Then('the response must contain a header with the redirect url', function () {
   expect(this.response.response.headers.location).to.equal(newRepository);
 });
 

--- a/test/features/support/GithubAPI/Redirect/RedirectSteps.js
+++ b/test/features/support/GithubAPI/Redirect/RedirectSteps.js
@@ -8,13 +8,13 @@ const { setAuthorizationHeaders } = require('../../helpers/helpers');
 let oldRepository;
 let newRepository;
 
-Given('a Github a repository old URL', () => {
+Given('a Github a repository old URL {string}', (oldURL) => {
   setAuthorizationHeaders(agent);
-  oldRepository = 'https://github.com/aperdomob/redirect-test';
+  oldRepository = oldURL;
 });
 
-Given('the Github repository new URL', () => {
-  newRepository = 'https://github.com/aperdomob/new-redirect-test';
+Given('the Github repository new URL {string}', (newURL) => {
+  newRepository = newURL;
 });
 
 When('a request is used to obtain information of the repository, with the old URL', async function () {

--- a/test/features/support/GithubAPI/Redirect/RedirectSteps.js
+++ b/test/features/support/GithubAPI/Redirect/RedirectSteps.js
@@ -1,0 +1,38 @@
+const defaults = require('superagent-defaults');
+
+const agent = defaults();
+const { Given, When, Then } = require('cucumber');
+const { expect } = require('chai');
+const { setAuthorizationHeaders } = require('../../helpers/helpers');
+
+let oldRepository;
+let newRepository;
+
+Given('a Github a repository old URL', () => {
+  setAuthorizationHeaders(agent);
+  oldRepository = 'https://github.com/aperdomob/redirect-test';
+});
+
+Given('the Github repository new URL', () => {
+  newRepository = 'https://github.com/aperdomob/new-redirect-test';
+});
+
+When('a request is used to obtain information of the repository, with the old URL', async function () {
+  try {
+    await agent.head(oldRepository);
+  } catch (response) {
+    this.response = response;
+  }
+});
+
+Then('the repository redirect information', function () {
+  expect(this.response.response.headers.location).to.equal(newRepository);
+});
+
+When('a request is used to retrieve the repository with the old URL', async function () {
+  this.response = await agent.get(oldRepository);
+});
+
+Then('the response must contain a redirect to the new URL', function () {
+  expect(this.response.redirects).to.include(newRepository);
+});

--- a/test/features/support/common/statusCode.js
+++ b/test/features/support/common/statusCode.js
@@ -16,6 +16,9 @@ Then('the response should contain a {string} status', function (status) {
     case 'Not-Found':
       expect(this.response.status).to.equal(statusCode.NOT_FOUND);
       break;
+    case 'Moved-Permanently':
+      expect(this.response.status).to.equal(statusCode.MOVED_PERMANENTLY);
+      break;
     default:
       break;
   }


### PR DESCRIPTION
Redirect testing using HEAD requests. 

The try catch i used in the test, is because "Moved_Permanently" Status Code makes super agent to throw an exception